### PR TITLE
VLN-530: Set explicit permissions for GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
       - "releases/*"
+permissions:
+  contents: read
 
 jobs:
   build-lint-test:


### PR DESCRIPTION
## Summary

- `.github/workflows/ci.yml`: Added workflow-level permissions at .github/workflows/ci.yml:8 to restrict the GITHUB_TOKEN to read-only repository contents, aligning with least privilege; consider triggering the workflow to confirm no further permissions are required.